### PR TITLE
Moving Data Directory to ~/.config when running under Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with urlopen(url="https://github.com/akashnag/ash/raw/master/PYPI_README.md") as
 
 setup(
 	name="ash-editor",
-    version="0.1.0-dev12",
+    version="0.1.0-dev13",
 	description='A modern terminal text-editor',
 	classifiers=[
 	'License :: OSI Approved :: MIT License',

--- a/src/ash/__init__.py
+++ b/src/ash/__init__.py
@@ -13,7 +13,7 @@ import glob
 import subprocess
 
 __version__			= "0.1.0-dev"
-__build__			= "12"
+__build__			= "13"
 __release_date__	= "Feb 20, 2022"
 
 APP_COPYRIGHT_TEXT	= "© Copyright 2020-2022, Akash Nag. All rights reserved."
@@ -39,7 +39,7 @@ MIN_EDITOR_WIDTH	= 15
 MIN_EDITOR_HEIGHT	= 5
 
 # path to the application data directory and configuration files
-APP_DATA_DIR			= os.path.join(os.path.expanduser("~"), ".ash-editor")
+APP_DATA_DIR			= os.path.join(os.path.expanduser("~"), ".config", "ash-editor")
 APP_PLUGINS_DIR			= os.path.join(APP_DATA_DIR, "plugins")
 APP_KEYMAPS_DIR			= os.path.join(APP_DATA_DIR, "keymaps")
 APP_THEMES_DIR			= os.path.join(APP_DATA_DIR, "themes")

--- a/src/ash/__init__.py
+++ b/src/ash/__init__.py
@@ -11,6 +11,7 @@ import sys
 import copy
 import glob
 import subprocess
+import platform
 
 __version__			= "0.1.0-dev"
 __build__			= "13"
@@ -39,7 +40,10 @@ MIN_EDITOR_WIDTH	= 15
 MIN_EDITOR_HEIGHT	= 5
 
 # path to the application data directory and configuration files
-APP_DATA_DIR			= os.path.join(os.path.expanduser("~"), ".config", "ash-editor")
+if platform.system() == "Linux":
+    APP_DATA_DIR			= os.path.join(os.path.expanduser("~"), ".config", "ash-editor")
+else:
+    APP_DATA_DIR			= os.path.join(os.path.expanduser("~"), ".ash-editor")
 APP_PLUGINS_DIR			= os.path.join(APP_DATA_DIR, "plugins")
 APP_KEYMAPS_DIR			= os.path.join(APP_DATA_DIR, "keymaps")
 APP_THEMES_DIR			= os.path.join(APP_DATA_DIR, "themes")


### PR DESCRIPTION
A recommendation to move the configs to ~/.config as to not clutter the users Home Directory. There is an argument to only put the actual config file there and leave themes and keymaps elsewhere, but i feel like this is a simple Solution.
I added a check for the OS we are running under to not complicate Paths in Windows. I importet the platform module for that, as it's output is simpler. Similar result could be achieved with `os.name` , if the additional library is unwanted.